### PR TITLE
Changed the AndroidManifest to open the SearchBarActivity on app launch.

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,13 +26,14 @@
         <activity
             android:name=".MainActivity"
             android:label="@string/app_name">
+        </activity>
+        <activity android:name=".SearchBarActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".SearchBarActivity"></activity>
     </application>
 
 </manifest>


### PR DESCRIPTION
Hi,
The null pointer exception was a result of the MainActivity not getting any input text (Do fix that too in case anyone presses the search button without entering any query). This happened sice your app's opening activity was set to MainActivity in the manifest.

You had to slightly modify the AndroidManifest so that your app correctly opened the SearchBarActivity.